### PR TITLE
feat(tensorboard): add 'log' update mode; stabilize e2e; Windows temp files

### DIFF
--- a/ml_playground/configuration/models.py
+++ b/ml_playground/configuration/models.py
@@ -178,6 +178,7 @@ class RuntimeConfig(_FrozenStrictModel):
     dtype: DTypeKind = "float32"
     compile: bool = False
     tensorboard_enabled: bool = True
+    tensorboard_update_mode: Literal["eval", "log"] = "eval"
     always_save_checkpoint: bool = False
     iters_per_epoch: Optional[EpochCount] = None
     max_epochs: Optional[EpochCount] = None

--- a/ml_playground/experiments/bundestag_char/config.toml
+++ b/ml_playground/experiments/bundestag_char/config.toml
@@ -75,6 +75,8 @@ eval_interval = 25
 eval_iters = 10
 # How often (in iterations) to log training metrics.
 log_interval = 25
+# Controls when to write TensorBoard logs: "eval" (on evaluation only) or "log" (on every log_interval step). Defaults to "eval" if unset or unknown.
+tensorboard_update_mode = "eval"
 # If true, only runs evaluation and exits (no training updates); useful for validating or benchmarking.
 eval_only = false
 # If true, save a checkpoint on every eval (last and/or best/top-k as configured); increases disk usage.

--- a/ml_playground/training/loop/runner.py
+++ b/ml_playground/training/loop/runner.py
@@ -162,6 +162,23 @@ class Trainer:
                         batch_size=self.cfg.data.batch_size,
                         grad_accum_steps=self.cfg.data.grad_accum_steps,
                     )
+                    # TensorBoard logging if update mode is 'log'
+                    try:
+                        if (
+                            self.writer
+                            and getattr(
+                                self.cfg.runtime, "tensorboard_update_mode", "eval"
+                            )
+                            == "log"
+                        ):
+                            scaled_loss = loss.item() * self.cfg.data.grad_accum_steps
+                            self.writer.add_scalar(
+                                "Loss/train", scaled_loss, self.iter_num
+                            )
+                            self.writer.add_scalar("LR", lr, self.iter_num)
+                    except Exception:
+                        # Never fail training loop due to TB writer issues
+                        pass
 
                 self.iter_num += 1
                 local_iter_num += 1

--- a/tests/e2e/ml_playground/experiments/bundestag_char/test_cli_bundestag_char.py
+++ b/tests/e2e/ml_playground/experiments/bundestag_char/test_cli_bundestag_char.py
@@ -36,9 +36,12 @@ def tmp_dataset(tmp_path: Path) -> Path:
 
 def _write_exp_config(tmp_dir: Path, out_dir: Path, dataset_dir: Path) -> Path:
     """Create a minimal, strict experiment config TOML pointing to tmp paths."""
+    # Ensure Windows paths are properly escaped for TOML
+    dataset_dir_str = str(dataset_dir).replace("\\", "\\\\")
+    out_dir_str = str(out_dir).replace("\\", "\\\\")
     cfg = f'''
 [prepare]
-dataset_dir = "{dataset_dir}"
+dataset_dir = "{dataset_dir_str}"
 tokenizer_type = "char"
 
 [train.model]
@@ -85,8 +88,8 @@ lr_decay_iters = 2
 min_lr = 0.00008
 
 [train.runtime]
-out_dir = "{out_dir}"
-max_iters = 2
+out_dir = "{out_dir_str}"
+max_iters = 4
 eval_interval = 1
 eval_iters = 1
 log_interval = 1
@@ -101,7 +104,7 @@ last = 1
 best = 1
 
 [sample.runtime]
-out_dir = "{out_dir}"
+out_dir = "{out_dir_str}"
 device = "cpu"
 dtype = "float32"
 compile = false

--- a/tests/unit/configuration/test_property.py
+++ b/tests/unit/configuration/test_property.py
@@ -155,6 +155,7 @@ class TestTomlReading:
             try:
                 tomli_w.dump(content, f)
                 f.flush()
+                f.close()
                 path = Path(f.name)
                 result = config_loading.read_toml_dict(path)
                 assert isinstance(result, dict)
@@ -174,6 +175,7 @@ class TestTomlReading:
             try:
                 f.write(content)
                 f.flush()
+                f.close()
                 path = Path(f.name)
                 if content.strip():
                     with pytest.raises((Exception, tomllib.TOMLDecodeError)):

--- a/tests/unit/data_pipeline/test_memmap.py
+++ b/tests/unit/data_pipeline/test_memmap.py
@@ -56,6 +56,7 @@ class TestMemmapReader:
             try:
                 test_data.tofile(f)
                 f.flush()
+                f.close()
 
                 path = Path(f.name)
                 reader = MemmapReader.open(path, dtype=np.uint16)
@@ -101,6 +102,7 @@ class TestSampleBatch:
                 )
                 test_data.tofile(f)
                 f.flush()
+                f.close()
 
                 path = Path(f.name)
                 reader = MemmapReader.open(path, dtype=np.uint16)

--- a/tests/unit/data_pipeline/test_sampling.py
+++ b/tests/unit/data_pipeline/test_sampling.py
@@ -56,6 +56,7 @@ class TestMemmapReader:
             try:
                 test_data.tofile(f)
                 f.flush()
+                f.close()
 
                 path = Path(f.name)
                 reader = MemmapReader.open(path, dtype=np.uint16)
@@ -101,6 +102,7 @@ class TestSampleBatch:
                 )
                 test_data.tofile(f)
                 f.flush()
+                f.close()
 
                 path = Path(f.name)
                 reader = MemmapReader.open(path, dtype=np.uint16)


### PR DESCRIPTION
Add tensorboard_update_mode ('eval'|'log') and log TB scalars at log_interval in 'log' mode; e2e reliability (max_iters=4); Windows temp file handling fixes. Tests and hooks pass.