### PR TITLE
docs: fix markdownlint violations

### DIFF
--- a/.dev-guidelines/DEVELOPMENT.md
+++ b/.dev-guidelines/DEVELOPMENT.md
@@ -1,7 +1,7 @@
 ---
 trigger: always_on
-description: 
-globs: 
+description:
+globs:
 ---
 
 # ml_playground Development Practices
@@ -10,7 +10,8 @@ Core development practices, quality standards, and workflow for ml_playground co
 
 ## Quality Gates (Mandatory)
 
-For detailed information about the centralized framework utilities, see [Framework Utilities Documentation](../docs/framework_utilities.md).
+For detailed information about the centralized framework utilities, see [Framework Utilities
+Documentation](../docs/framework_utilities.md).
 
 Run this Make target before every commit (same commands under the hood):
 
@@ -29,8 +30,11 @@ CI and pre-commit both invoke `make quality` as the core gate.
 - **One logical change per commit** (e.g., fix a test, adjust a config, refactor a function)
 - **Keep commits under ~200 lines** unless unavoidable
 - **Run quality gates before each commit**, not just before PR
-- **Pairing rule (REQUIRED)**: Each functional or behavioral change MUST include its tests in the same commit (unit and/or integration). Creating new files (untracked) is expected when adding tests—stage them together with the production change.
-- **Granularity**: Prefer a short sequence of TDD commits to a single large commit. Each step should keep the suite green.
+- **Pairing rule (REQUIRED)**: Each functional or behavioral change MUST include its tests in the same commit (unit
+  and/or integration). Creating new files (untracked) is expected when adding tests—stage them together with the
+  production change.
+- **Granularity**: Prefer a short sequence of TDD commits to a single large commit. Each step should keep the suite
+  green.
 
 ### Practical Tips
 
@@ -38,8 +42,10 @@ CI and pre-commit both invoke `make quality` as the core gate.
 - Separate mechanical formatting from semantic changes
 - Split large features into reviewable increments
 - Keep tests passing at every step
-- Pair production and test changes: when adding/refactoring code, include the minimal tests that specify the behavior in the same commit.
-- Acceptable exceptions: documentation only commits, pure test refactors (no behavior change), or mechanical formatting. For everything else, pair code+tests.
+- Pair production and test changes: when adding/refactoring code, include the minimal tests that specify the behavior in
+  the same commit.
+- Acceptable exceptions: documentation only commits, pure test refactors (no behavior change), or mechanical formatting.
+  For everything else, pair code+tests.
 
 ### Runnable State Requirement (MANDATORY)
 
@@ -48,7 +54,8 @@ CI and pre-commit both invoke `make quality` as the core gate.
   - `make quality` passes locally (same as pre-commit/CI gate).
   - No partially applied migrations or broken CLI entry points.
   - Documentation build (if modified) is not broken.
-- Do not commit code that knowingly breaks the build with intent to "fix later". Split work into smaller, independently runnable commits.
+- Do not commit code that knowingly breaks the build with intent to "fix later". Split work into smaller, independently
+  runnable commits.
 
 ### Branching Model (Feature Branches REQUIRED)
 
@@ -83,7 +90,8 @@ Ruff automatically applies modern Python best practices:
 - **Configuration and overrides**:
   - TOML is the primary source of truth; avoid ad-hoc CLI flags that mutate config.
   - Allowed exceptions (documented and tested):
-    - Global CLI option `--exp-config PATH` to choose a specific experiment TOML; `experiments/default_config.toml` is merged first.
+    - Global CLI option `--exp-config PATH` to choose a specific experiment TOML; `experiments/default_config.toml` is
+      merged first.
     - Environment JSON overrides: `ML_PLAYGROUND_TRAIN_OVERRIDES` and `ML_PLAYGROUND_SAMPLE_OVERRIDES`.
       These are deep-merged and then strictly re-validated; invalid env overrides are ignored.
 
@@ -96,7 +104,7 @@ Ruff automatically applies modern Python best practices:
 **Centralized sections**:
 
 - `[tool.ruff]` for lint/format settings
-- `[tool.mypy]` for type checker settings  
+- `[tool.mypy]` for type checker settings
 - `[tool.pyright]` for static analysis include/exclude
 - `[tool.pytest.ini_options]` for pytest testpaths and options
 

--- a/.dev-guidelines/DOCUMENTATION.md
+++ b/.dev-guidelines/DOCUMENTATION.md
@@ -5,13 +5,16 @@ description: documentation standards for nanoGPT/ml_playground
 
 # Documentation Guidelines
 
-Unified standards for all documentation in this repository. Applies to top-level docs, module docs, experiment READMEs, tests READMEs, and tools.
+Unified standards for all documentation in this repository. Applies to top-level docs, module docs, experiment
+READMEs, tests READMEs, and tools.
 
 ## Abstraction Policy
 
 - Top level (repo `README.md`): high-level orientation and entrypoints only.
-- Mid level (e.g., `ml_playground/experiments/Readme.md`): overview of experiments and shared conventions. Avoid per-file details.
-- Low level (e.g., `ml_playground/experiments/<name>/Readme.md`): operational detail to run the experiment, but remain concise. Defer general concepts to shared docs.
+- Mid level (e.g., `ml_playground/experiments/Readme.md`): overview of experiments and shared conventions. Avoid per-file
+  details.
+- Low level (e.g., `ml_playground/experiments/<name>/Readme.md`): operational detail to run the experiment, but remain
+  concise. Defer general concepts to shared docs.
 - The deeper you go in the tree, the more concrete the instructions — but keep them brief and avoid duplication.
 
 ## Required Sections per Experiment Readme
@@ -46,7 +49,8 @@ ml_playground/experiments/shakespeare/
 
 ## Linking to Framework Docs
 
-- When referring to shared helpers or patterns, link to `docs/framework_utilities.md` rather than duplicating explanations.
+- When referring to shared helpers or patterns, link to `docs/framework_utilities.md` rather than duplicating
+  explanations.
 - Example line: “For framework utilities, see `docs/framework_utilities.md`.”
 
 ## Markdown Style (markdownlint)
@@ -61,7 +65,8 @@ ml_playground/experiments/shakespeare/
 
 - Use relative links within the repository: `../../docs/framework_utilities.md` from experiment folders.
 - Prefer short, stable link text.
-- When linking to another folder, link to that folder's `Readme.md` (single entry point) instead of deep files. Deep documents should be discovered from that folder's `Readme.md`.
+- When linking to another folder, link to that folder's `Readme.md` (single entry point) instead of deep files. Deep
+  documents should be discovered from that folder's `Readme.md`.
 
 ## DRY Documentation
 
@@ -79,8 +84,10 @@ ml_playground/experiments/shakespeare/
 
 - Docs must pass `make quality` (markdownlint part of our checks) before commit.
 - Prefer granular commits with clear `docs(<area>): <subject>` messages.
-- When documenting functional changes to code, ensure the associated commit pairs production code and tests in the same change per TDD policy (see `DEVELOPMENT.md`).
-- Reviewers check: abstraction level appropriate, tree annotated, headings/lists/code blocks spacing correct, and links valid.
+- When documenting functional changes to code, ensure the associated commit pairs production code and tests in the same
+  change per TDD policy (see `DEVELOPMENT.md`).
+- Reviewers check: abstraction level appropriate, tree annotated, headings/lists/code blocks spacing correct, and links
+  valid.
 
 ## Tests and Tools READMEs
 

--- a/.dev-guidelines/GIT_VERSIONING.md
+++ b/.dev-guidelines/GIT_VERSIONING.md
@@ -5,7 +5,8 @@ description: Git branching, versioning, and commit policy
 
 # Git Versioning & Workflow
 
-Canonical rules for branches, commit messages, and history management. Keep commits runnable and history linear to maintain velocity and reliability.
+Canonical rules for branches, commit messages, and history management. Keep commits runnable and history linear to
+maintain velocity and reliability.
 
 ## Branching Model (Feature Branches REQUIRED)
 

--- a/.dev-guidelines/IMPORT_GUIDELINES.md
+++ b/.dev-guidelines/IMPORT_GUIDELINES.md
@@ -1,7 +1,7 @@
 ---
 trigger: always_on
-description: 
-globs: 
+description:
+globs:
 ---
 
 # Import Guidelines: Strict Policy and Rationale
@@ -57,7 +57,8 @@ This is a prescriptive, low‑choice standard for all Python imports in the code
 
 9. **Cycle handling**
    - First choice: refactor to remove the cycle (extract shared code to a lower-level module).
-   - If refactor is not immediately feasible, a single, narrowly-scoped local import is permitted inside the function that needs it, with a code comment "Cycle break: short rationale". Track a task to remove the cycle.
+   - If refactor is not immediately feasible, a single, narrowly-scoped local import is permitted inside the function
+     that needs it, with a code comment "Cycle break: short rationale". Track a task to remove the cycle.
 
 10. **Type-only imports**
     - Use typing.TYPE_CHECKING guards for heavy or optional typing dependencies.
@@ -65,7 +66,8 @@ This is a prescriptive, low‑choice standard for all Python imports in the code
 
 11. **Lazy imports**
     - Not allowed by default.
-    - Allowed only when both conditions hold: breaks a hard import cycle or defers a large, cold-path dependency with measurable startup benefit. Must be documented with a comment "Lazy import: <reason + expected impact>".
+    - Allowed only when both conditions hold: breaks a hard import cycle or defers a large, cold-path dependency with
+      measurable startup benefit. Must be documented with a comment "Lazy import: <reason + expected impact>".
 
 12. ****init**.py usage**
     - May exist for package recognition or minimal metadata only.
@@ -117,7 +119,8 @@ def compute():
 
 - Run the project's linter/formatter/import organizer before every commit to enforce ordering and grouping.
 - Type checkers must pass with type-only guards for heavy/optional types.
-- Changes to import structure should follow TDD and be committed with paired tests when behavior or public API surface changes.
+- Changes to import structure should follow TDD and be committed with paired tests when behavior or public API surface
+  changes.
 
 ## Review Checklist (Must Pass All)
 

--- a/.dev-guidelines/REQUIREMENTS.md
+++ b/.dev-guidelines/REQUIREMENTS.md
@@ -8,7 +8,8 @@ globs: *.py, *.md, *.toml
 
 ## Overview
 
-The checkpointing system manages model snapshots during training to enable resuming training and model evaluation. The system should be strict and well-defined with clear behavior.
+The checkpointing system manages model snapshots during training to enable resuming training and model evaluation. The
+system should be strict and well-defined with clear behavior.
 
 ## Configuration
 
@@ -66,17 +67,23 @@ The checkpointing system manages model snapshots during training to enable resum
 
 ## Filesystem Access and Path Suppliers
 
-- The configuration loader (`ml_playground.config_loader`) is the single boundary that interacts with the filesystem for configuration concerns (parsing TOML, resolving and coercing paths, injecting logger).
+- The configuration loader (`ml_playground.config_loader`) is the single boundary that interacts with the filesystem for
+  configuration concerns (parsing TOML, resolving and coercing paths, injecting logger).
   - Reads TOML files (defaults and experiment config) using strict UTF-8 parsing.
   - Resolves known relative paths relative to the config file directory when appropriate.
   - Coerces string paths to `pathlib.Path` objects before validation.
   - Injects required runtime context (e.g., logger) prior to strict Pydantic validation.
-- All other modules must treat `Path` values as already validated inputs and must not perform additional path resolution or ad-hoc filesystem probing beyond their explicit responsibilities (e.g., training writing checkpoints, sampler reading checkpoints). Runtime commands may perform existence checks for required runtime artifacts (see Universal Meta Requirement).
+- All other modules must treat `Path` values as already validated inputs and must not perform additional path resolution
+  or ad-hoc filesystem probing beyond their explicit responsibilities (e.g., training writing checkpoints, sampler
+  reading checkpoints). Runtime commands may perform existence checks for required runtime artifacts (see Universal Meta
+  Requirement).
 - No fallback or legacy behavior: invalid or missing paths must surface as early errors during load/validation.
-- To keep call sites simple and decoupled from path layout, the loader should expose supplier functions (thin helpers) that return the canonical `Path` objects needed by downstream components. Examples:
+- To keep call sites simple and decoupled from path layout, the loader should expose supplier functions (thin helpers)
+  that return the canonical `Path` objects needed by downstream components. Examples:
   - `get_cfg_path(experiment: str, exp_config: Path | None) -> Path` (already provided)
   - `get_default_config_path(config_path: Path) -> Path` (already provided)
-  - If needed, additional suppliers for derived locations (e.g., experiment directories) should live in `config_loader` and not be re-implemented elsewhere.
+  - If needed, additional suppliers for derived locations (e.g., experiment directories) should live in `config_loader`
+    and not be re-implemented elsewhere.
 
 ## Universal Meta Requirement
 
@@ -90,4 +97,5 @@ The checkpointing system manages model snapshots during training to enable resum
     - Train: requires `train.data.meta_path` to exist.
     - Sample: requires `train.data.meta_path` or `<sample.runtime.out_dir>/<experiment>/meta.pkl` to exist.
     - Loop: skipping prepare requires `train.bin`, `val.bin`, and `meta.pkl` to be present.
-  - Rationale: keeps config loading deterministic and testable without a filesystem, while still failing early at execution time when artifacts are missing.
+  - Rationale: keeps config loading deterministic and testable without a filesystem, while still failing early at
+    execution time when artifacts are missing.

--- a/.dev-guidelines/Readme.md
+++ b/.dev-guidelines/Readme.md
@@ -4,7 +4,8 @@ trigger: always_on
 
 # ml_playground Developer Guidelines
 
-**Audience**: Advanced contributors working exclusively on the `ml_playground` module. These rules are binding. Follow them exactly.
+**Audience**: Advanced contributors working exclusively on the `ml_playground` module. These rules are binding. Follow
+them exactly.
 
 ## Quick Start
 
@@ -61,7 +62,8 @@ This guideline system is organized into focused documents for easy navigation:
 - Platform-specific solutions
 - Development workflow fixes
 
-**UV-Only Workflow**: Use UV for everything - virtualenv, dependency sync, running tools and tests. No pip, requirements.txt, or manual venv activation.
+**UV-Only Workflow**: Use UV for everything - virtualenv, dependency sync, running tools and tests. No pip,
+requirements.txt, or manual venv activation.
 
 All documentation in this repo must adhere to [DOCUMENTATION.md](DOCUMENTATION.md).
 
@@ -74,17 +76,22 @@ All documentation in this repo must adhere to [DOCUMENTATION.md](DOCUMENTATION.m
 - Type checking
 - Tests with warnings as errors
 
-**Granular Commits**: Make small, focused commits with conventional commit messages. Run quality gates before each commit, not just before PR.
+**Granular Commits**: Make small, focused commits with conventional commit messages. Run quality gates before each
+commit, not just before PR.
 
-**Runnable Commits**: Every commit must be in a runnable state when checked out. Do not land commits that break `make quality`, CLI entry points, or docs builds. Never bypass verification (avoid `--no-verify`).
+**Runnable Commits**: Every commit must be in a runnable state when checked out. Do not land commits that break `make
+quality`, CLI entry points, or docs builds. Never bypass verification (avoid `--no-verify`).
 
-**Feature Branches Only**: All work happens on short‑lived feature branches; no direct commits to `main`. Use kebab-case names like `feat/<scope>-<short-desc>`, `fix/<scope>-<short-desc>`. Keep branches focused and prefer multiple small PRs.
+**Feature Branches Only**: All work happens on short‑lived feature branches; no direct commits to `main`. Use kebab-case
+names like `feat/<scope>-<short-desc>`, `fix/<scope>-<short-desc>`. Keep branches focused and prefer multiple small PRs.
 
 **TOML Configuration**: TOML is the primary source of truth, mapped to dataclasses. No ad‑hoc CLI parameter overrides.
 
 - Allowed exceptions (as implemented):
-  - Global CLI option `--exp-config PATH` selects an alternative experiment TOML file (replaces the experiment’s `config.toml`). The global `experiments/default_config.toml` is still merged first under the experiment config.
-  - Environment JSON overrides are supported, deep-merged, and strictly re-validated; invalid overrides are ignored to avoid breaking flows:
+  - Global CLI option `--exp-config PATH` selects an alternative experiment TOML file (replaces the experiment’s
+    `config.toml`). The global `experiments/default_config.toml` is still merged first under the experiment config.
+  - Environment JSON overrides are supported, deep-merged, and strictly re-validated; invalid overrides are ignored to
+    avoid breaking flows:
     - `ML_PLAYGROUND_TRAIN_OVERRIDES`
     - `ML_PLAYGROUND_SAMPLE_OVERRIDES`
 
@@ -125,7 +132,7 @@ make loop bundestag_char CONFIG=ml_playground/configs/bundestag_char_cpu.toml
 ## Need Help?
 
 - **Setup issues**: See [SETUP.md](SETUP.md) for installation and basic workflow
-- **Development questions**: Check [DEVELOPMENT.md](DEVELOPMENT.md) for practices and standards  
+- **Development questions**: Check [DEVELOPMENT.md](DEVELOPMENT.md) for practices and standards
 - **Import problems**: Review [IMPORT_GUIDELINES.md](IMPORT_GUIDELINES.md) for strict policies
 - **Troubleshooting**: Consult [TROUBLESHOOTING.md](TROUBLESHOOTING.md) for common issues
 
@@ -139,4 +146,5 @@ make loop bundestag_char CONFIG=ml_playground/configs/bundestag_char_cpu.toml
 
 ---
 
-*This guideline system ensures consistent, high-quality development practices across the ml_playground module. Each document focuses on a specific aspect while maintaining coherent overall standards.*
+*This guideline system ensures consistent, high-quality development practices across the ml_playground module. Each
+document focuses on a specific aspect while maintaining coherent overall standards.*

--- a/.dev-guidelines/SETUP.md
+++ b/.dev-guidelines/SETUP.md
@@ -38,8 +38,10 @@ make prepare bundestag_char
 
 Notes:
 
-- The prepare step is responsible for writing `meta.pkl` into your dataset directory alongside `train.bin` and `val.bin`.
-- If you use a custom preparer, ensure it calls `ml_playground.prepare.write_bin_and_meta(...)` or equivalent utilities which always write a standardized `meta.pkl`.
+- The prepare step is responsible for writing `meta.pkl` into your dataset directory alongside `train.bin` and
+  `val.bin`.
+- If you use a custom preparer, ensure it calls `ml_playground.prepare.write_bin_and_meta(...)` or equivalent
+  utilities which always write a standardized `meta.pkl`.
 
 ### Training
 
@@ -50,7 +52,8 @@ make train bundestag_char CONFIG=ml_playground/configs/bundestag_char_cpu.toml
 
 Notes:
 
-- Universal meta policy: training requires `meta.pkl` to exist at `train.data.meta_path` (usually `<dataset_dir>/meta.pkl`).
+- Universal meta policy: training requires `meta.pkl` to exist at `train.data.meta_path` (usually
+  `<dataset_dir>/meta.pkl`).
 - The CLI will fail fast with a clear error if `meta.pkl` is missing.
 
 ### Sampling
@@ -62,7 +65,8 @@ make sample bundestag_char CONFIG=ml_playground/configs/bundestag_char_cpu.toml
 
 Notes:
 
-- Sampling requires `meta.pkl` to exist either at `train.data.meta_path` or under the sample runtime output directory at `<out_dir>/<experiment>/meta.pkl`.
+- Sampling requires `meta.pkl` to exist either at `train.data.meta_path` or under the sample runtime output directory at
+  `<out_dir>/<experiment>/meta.pkl`.
 - The CLI will fail fast with a clear error if `meta.pkl` cannot be found in one of the expected locations.
 
 ### End-to-End Loop
@@ -73,15 +77,19 @@ make loop bundestag_char CONFIG=ml_playground/configs/bundestag_char_cpu.toml
 
 Make output is intentionally quieter by default via a global `.SILENT:` directive; only explicit messages are printed.
 
-- The loop will only skip the prepare step if `train.bin`, `val.bin`, and `meta.pkl` are present in the dataset directory.
+- The loop will only skip the prepare step if `train.bin`, `val.bin`, and `meta.pkl` are present in the dataset
+  directory.
 
 ## Configuration System
 
-- All configuration via TOML- __Single Source of Truth for Configuration__
+- All configuration via TOML — __Single Source of Truth for Configuration__
   - Use the `ml_playground/configuration/` package as the only configuration authority (`models`, `loading`, `cli`).
-  - Prefer `configuration.loading.load_experiment_toml()` (or `load_full_experiment_config`) and strongly typed models: `ExperimentConfig`, `TrainerConfig`, `SamplerConfig`, `RuntimeConfig`.
-  - Global CLI option `--exp-config PATH` selects an alternative experiment TOML file (replaces the experiment’s `config.toml`). The global `experiments/default_config.toml` is still merged first under the experiment config.
-  - Environment JSON overrides are supported, deep-merged, and strictly re-validated; invalid overrides are ignored to avoid breaking flows:
+  - Prefer `configuration.loading.load_experiment_toml()` (or `load_full_experiment_config`) and strongly typed models:
+    `ExperimentConfig`, `TrainerConfig`, `SamplerConfig`, `RuntimeConfig`.
+  - Global CLI option `--exp-config PATH` selects an alternative experiment TOML file (replaces the experiment’s
+    `config.toml`). The global `experiments/default_config.toml` is still merged first under the experiment config.
+  - Environment JSON overrides are supported, deep-merged, and strictly re-validated; invalid overrides are ignored to
+    avoid breaking flows:
     - `ML_PLAYGROUND_TRAIN_OVERRIDES`
     - `ML_PLAYGROUND_SAMPLE_OVERRIDES`
 - Paths automatically converted to `pathlib.Path` objects
@@ -110,7 +118,8 @@ make quality-ext
 2. Implement the minimal production code to make the test pass.
 3. Refactor with tests green.
 
-Commit pairing rule (required): each functional change MUST include its tests in the same commit (unit/integration). Exceptions: documentation-only, test-only refactors (no behavior change), mechanical formatting.
+Commit pairing rule (required): each functional change MUST include its tests in the same commit (unit/integration).
+Exceptions: documentation-only, test-only refactors (no behavior change), mechanical formatting.
 
 Recommended commit sequence per behavior:
 

--- a/.dev-guidelines/TESTING.md
+++ b/.dev-guidelines/TESTING.md
@@ -41,9 +41,12 @@ Testing Docs
 
 ### 2. Test Levels (ULTRA-STRICT Performance Requirements)
 
-- **Unit tests** (required): LIGHTNING FAST (<10ms each), isolated, no network, no filesystem writes. One spec per behavior. MUST achieve 100% success rate.
-- **Integration tests** (allowed/required): Minimal real integration across 2–3 components, no live external services. Use in-memory or ephemeral resources. Must complete in <100ms each.
-- **End-to-end tests** (discouraged): Only when explicitly approved; must run in CI under 30s total with recorded/replayed I/O.
+- **Unit tests** (required): LIGHTNING FAST (<10ms each), isolated, no network, no filesystem writes. One spec per
+  behavior. MUST achieve 100% success rate.
+- **Integration tests** (allowed/required): Minimal real integration across 2–3 components, no live external services.
+  Use in-memory or ephemeral resources. Must complete in <100ms each.
+- **End-to-end tests** (discouraged): Only when explicitly approved; must run in CI under 30s total with
+  recorded/replayed I/O.
 
 **Rationale**: Speed is critical for developer productivity; any slow test breaks the flow.
 
@@ -51,7 +54,8 @@ Testing Docs
 
 - **Structure** (canonical): `tests/unit/<package>/test_<module>.py`
 - **Packages** mirror `ml_playground/` layout, for example:
-  - `tests/unit/training/`, `tests/unit/sampling/`, `tests/unit/data_pipeline/`, `tests/unit/configuration/`, `tests/unit/core/`, `tests/unit/experiments/`, `tests/unit/analysis/`
+  - `tests/unit/training/`, `tests/unit/sampling/`, `tests/unit/data_pipeline/`, `tests/unit/configuration/`,
+    `tests/unit/core/`, `tests/unit/experiments/`, `tests/unit/analysis/`
 - **Test functions**: `test_<behavior>_<condition>_<expected>()`
 - **Test classes** (if grouping needed): `Test<Subject>` only; no `__init__` in test classes.
 - **Docstrings**: Each test function must have a one-line docstring stating the behavior it covers.
@@ -99,12 +103,14 @@ ml_playground/models/                     -> tests/unit/core/test_<module>.py
 ### 5.1 No Test-Specific Code Paths in Production (Non-Negotiable)
 
 - Production code must never contain branches, flags, or behavior that exists only to satisfy tests.
-  - Examples of forbidden patterns: `if TESTING: ...`, checking `PYTEST_CURRENT_TEST`, special test-only parameters, alternate I/O paths only under tests.
+  - Examples of forbidden patterns: `if TESTING: ...`, checking `PYTEST_CURRENT_TEST`, special test-only parameters,
+    alternate I/O paths only under tests.
 - Tests must exercise the same public API and code paths used in production.
 - Make code testable via proper seams instead:
   - Dependency injection with sensible production defaults (e.g., pass Path, clock, RNG, HTTP client).
   - Use pytest fixtures and mocks/monkeypatch for external boundaries (network, filesystem, time, env).
-- Idempotency and determinism are product qualities, not test toggles. Implement them unconditionally where applicable.
+- Idempotency and determinism are product qualities, not test toggles. Implement them unconditionally where
+  applicable.
 
 ### 6. Fixtures (Strict Usage)
 
@@ -154,13 +160,15 @@ ml_playground/models/                     -> tests/unit/core/test_<module>.py
 - **Per-module line coverage**: 100% for ALL `ml_playground/*` modules
 - **Branch coverage**: 100% for ALL modules (NO COMPROMISES)
 - **New/changed code**: Must achieve 100% coverage before merge
-- **No pragma comments**: ABSOLUTELY FORBIDDEN except for impossible-to-test code (if 0:, if **name** == **main**:)
+- **No pragma comments**: ABSOLUTELY FORBIDDEN except for impossible-to-test code (`if 0:`,
+  `if __name__ == "__main__":`).
 
 **Rationale**: Complete test coverage ensures zero blind spots and maximum confidence in code quality.
 
 ### 12. Flaky Test Policy (IMMEDIATE ACTION REQUIRED)
 
-**ABSOLUTE ZERO TOLERANCE**: Any flaky test is IMMEDIATELY removed from the suite. NO 24h grace period. NO xfail exceptions. NO second chances.
+**ABSOLUTE ZERO TOLERANCE**: Any flaky test is IMMEDIATELY removed from the suite. NO 24h grace period. NO xfail
+exceptions. NO second chances.
 
 **Enforcement**: First flake = immediate deletion. Tests must be 100% deterministic and reliable.
 
@@ -175,8 +183,10 @@ ml_playground/models/                     -> tests/unit/core/test_<module>.py
 make quality-ext
 ```
 
-- This initializes (if needed) and executes Cosmic Ray sessions at `.cache/cosmic-ray/session.sqlite`. The step is non-fatal and not part of CI or pre-commit by default.
-- The `.cache/cosmic-ray/` directory is treated like other build artifacts: never commit it, clean it with `make clean` if needed.
+- This initializes (if needed) and executes Cosmic Ray sessions at `.cache/cosmic-ray/session.sqlite`. The step is
+  non-fatal and not part of CI or pre-commit by default.
+- The `.cache/cosmic-ray/` directory is treated like other build artifacts: never commit it, clean it with `make clean`
+  if needed.
 
 ## Running Tests
 

--- a/.githooks/.pre-commit-config.yaml
+++ b/.githooks/.pre-commit-config.yaml
@@ -5,12 +5,18 @@ repos:
   - id: ruff
     args: [--fix]
   - id: ruff-format
+- repo: https://github.com/DavidAnson/markdownlint-cli2
+  rev: v0.15.0
+  hooks:
+  - id: markdownlint-cli2
+    args: ["--config", ".markdownlint-cli2.jsonc"]
+    files: '(README|CONTRIBUTING|LICENSE|CHANGELOG)\.md$|^(docs|tests|\.dev-guidelines)/.*\.md$'
 - repo: https://github.com/checkmake/checkmake.git
   # Or another commit hash or version
   rev: 0.2.2
   hooks:
   # Use this hook to let pre-commit build checkmake in its sandbox
-  -   id: checkmake
+  - id: checkmake
 - repo: local
   hooks:
   - id: pyright

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,10 @@
+{
+  "config": {
+    "MD013": {
+      "line_length": 120,
+      "heading_line_length": 120,
+      "code_blocks": false,
+      "tables": false
+    }
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -176,10 +176,17 @@ gguf-help: ## Show llama.cpp converter help
 	$(RUN) python tools/llama_cpp/convert-hf-to-gguf.py --help || true
 
 # Coverage helper
-coverage: ## Run coverage for non-performance tests and generate reports
-	$(RUN) coverage run -m pytest -m "not perf"
-	$(RUN) coverage report -m
-	$(RUN) coverage xml
+coverage: coverage-report ## [deprecated] use `make coverage-report`
+	@echo "[info] coverage-report completed; artifacts stored under .cache/coverage"
+
+coverage-report: ## Generate coverage reports (term, HTML, JSON) under .cache/coverage
+	mkdir -p .cache/coverage
+	$(RUN) coverage erase
+	$(RUN) coverage run -m pytest -n 0 -m "not perf"
+	$(RUN) coverage combine
+	$(RUN) coverage report -m --fail-under=0
+	$(RUN) coverage html -d .cache/coverage/htmlcov --fail-under=0
+	$(RUN) coverage json -o .cache/coverage/coverage.json --fail-under=0
 
 # ---------------------------------------------------------------------------
 # LIT: Minimal integration runner (persistent .venv312)

--- a/docs/LIT.md
+++ b/docs/LIT.md
@@ -1,6 +1,7 @@
 # LIT (Learning Interpretability Tool) — Minimal Integration
 
-The optional LIT UI lives under `ml_playground/analysis/lit/` and provides a tiny echo-model demo for quick inspection. We keep this minimal and isolated from the main project environment.
+The optional LIT UI lives under `ml_playground/analysis/lit/` and provides a tiny echo-model demo
+for quick inspection. We keep this minimal and isolated from the main project environment.
 
 ## Quickstart (UV, Python 3.12)
 

--- a/docs/framework_utilities.md
+++ b/docs/framework_utilities.md
@@ -1,10 +1,12 @@
 # Centralized Framework Utilities
 
-This document describes the centralized framework utilities that have been introduced to provide consistent error handling, progress reporting, and file operations across all experiments in the ml_playground.
+This document describes the centralized framework utilities that have been introduced to provide consistent error
+handling, progress reporting, and file operations across all experiments in the ml_playground.
 
 ## Overview
 
-The ml_playground now includes several centralized utility modules that provide standardized functionality for common operations:
+The ml_playground now includes several centralized utility modules that provide standardized functionality for common
+operations:
 
 1. `error_handling.py` - Centralized exception classes and error handling utilities
 2. `tokenizer.py` - Unified tokenizer protocol and implementations
@@ -68,21 +70,26 @@ The updated `ml_playground/prepare.py` module provides:
 ### File State Management
 
 - `snapshot_files(paths: Iterable[Path])` - Take a snapshot of file states for diffing later
-- `diff_files(paths: Iterable[Path], before: dict[Path, tuple[bool, float, int]])` - Compare file states and determine what changed
+- `diff_files(paths: Iterable[Path], before: dict[Path, tuple[bool, float, int]])` - Compare file states and determine
+  what changed
 
 ### Metadata Creation
 
-- `create_standardized_metadata(tokenizer: Tokenizer, train_tokens: int, val_tokens: int, extras: dict = None)` - Create standardized metadata for dataset preparation
+- `create_standardized_metadata(tokenizer: Tokenizer, train_tokens: int, val_tokens: int, extras: dict = None)` - Create
+  standardized metadata for dataset preparation
 
 ### Data Preparation Example
 
 - `split_train_val(text: str, split: float = 0.9)` - Split given text into train/val by ratio
-- `prepare_with_tokenizer(text: str, tokenizer: Tokenizer, split: float = 0.9)` - Prepare train/val data and metadata using a tokenizer
-- `write_bin_and_meta(ds_dir: Path, train: np.ndarray, val: np.ndarray, meta: dict)` - Write train.bin, val.bin, and meta.pkl atomically
+- `prepare_with_tokenizer(text: str, tokenizer: Tokenizer, split: float = 0.9)` - Prepare train/val data and metadata
+  using a tokenizer
+- `write_bin_and_meta(ds_dir: Path, train: np.ndarray, val: np.ndarray, meta: dict)` - Write train.bin, val.bin, and
+  meta.pkl atomically
 
 ## CLI Utilities
 
-The `ml_playground/cli.py` module provides the command-line interface for the framework. It uses a standardized structure for defining and running commands.
+The `ml_playground/cli.py` module provides the command-line interface for the framework. It uses a standardized
+structure for defining and running commands.
 
 ### Commands
 
@@ -113,13 +120,17 @@ Output is quieter by default due to a global `.SILENT:` in the Makefile; only ex
 
 ## Configuration System
 
-The framework uses a TOML-based configuration system with strict Pydantic models for validation and type safety. The configuration stack now lives under `ml_playground/configuration/`, which is split into three focused modules:
+The framework uses a TOML-based configuration system with strict Pydantic models for validation and type safety. The
+configuration stack now lives under `ml_playground/configuration/`, which is split into three focused modules:
 
 - `ml_playground/configuration/models.py` — all Pydantic schemas (`ExperimentConfig`, `TrainerConfig`, etc.).
-- `ml_playground/configuration/loading.py` — TOML IO helpers (`read_toml_dict`, `load_full_experiment_config`, section loaders) plus deep-merge utilities.
-- `ml_playground/configuration/cli.py` — adapters used by the Typer CLI (`load_experiment`, prerequisite checks, config path helpers).
+- `ml_playground/configuration/loading.py` — TOML IO helpers (`read_toml_dict`, `load_full_experiment_config`, section
+  loaders) plus deep-merge utilities.
+- `ml_playground/configuration/cli.py` — adapters used by the Typer CLI (`load_experiment`, prerequisite checks, config
+  path helpers).
 
-Legacy modules `ml_playground/config.py` and `ml_playground/config_loader.py` remain as thin re-export shims for compatibility but should not receive new logic.
+Legacy modules `ml_playground/config.py` and `ml_playground/config_loader.py` remain as thin re-export shims for
+compatibility but should not receive new logic.
 
 ### Config Models
 
@@ -133,46 +144,52 @@ Legacy modules `ml_playground/config.py` and `ml_playground/config_loader.py` re
 - `RuntimeConfig` — Output paths, device/dtype, seeding, checkpoint policy, logging, and loop cadence.
 - `SampleConfig` — Inference-time sampling knobs.
 
-All config models inherit from `_FrozenStrictModel` (immutable, `extra="forbid"`). `ExperimentConfig` always carries a `logger` (injected via default factory or overridden by the loader/CLI); section models do not define their own logger.
+All config models inherit from `_FrozenStrictModel` (immutable, `extra="forbid"`). `ExperimentConfig` always carries a
+`logger` (injected via default factory or overridden by the loader/CLI); section models do not define their own logger.
 
 ### Validated Type Aliases
 
 Common numeric constraints are expressed via annotated aliases:
 
-| Alias                         | Constraint                   | Example uses                                 |
-|-------------------------------|------------------------------|----------------------------------------------|
-| `AtLeastOneInt`               | `int >= 1`                   | `RuntimeConfig.eval_interval`, `DataConfig.batch_size` |
-| `NonNegativeStrictInt`        | `int >= 0`                   | `RuntimeConfig.max_iters`, `ckpt_top_k`      |
-| `PositiveStrictInt`           | `int > 0`                    | `ModelConfig.n_layer`, `n_head`, `n_embd`    |
-| `SeedInt`                     | `int >= 0`                   | `RuntimeConfig.seed`                          |
-| `MinutesNonNegative`          | `int >= 0`                   | `RuntimeConfig.ckpt_time_interval_minutes`    |
-| `UnitIntervalStrictFloat`     | `0.0 <= float <= 1.0`        | `RuntimeConfig.best_smoothing_alpha`, `ema_decay` |
-| `PosUnitIntervalStrictFloat`  | `0.0 < float <= 1.0`         | `SampleConfig.top_p`                          |
-| `NonNaNNonNegativeStrictFloat`| `float >= 0.0` and not NaN   | `OptimConfig.grad_clip`, `weight_decay`       |
-| `EpochCount`                  | alias of `AtLeastOneInt`     | `RuntimeConfig.iters_per_epoch`, `max_epochs` |
+- **`AtLeastOneInt`** (`int >= 1`): used by `RuntimeConfig.eval_interval`, `DataConfig.batch_size`.
+- **`NonNegativeStrictInt`** (`int >= 0`): used by `RuntimeConfig.max_iters`, `RuntimeConfig.ckpt_top_k`.
+- **`PositiveStrictInt`** (`int > 0`): used by `ModelConfig.n_layer`, `ModelConfig.n_head`, `ModelConfig.n_embd`.
+- **`SeedInt`** (`int >= 0`): used by `RuntimeConfig.seed`.
+- **`MinutesNonNegative`** (`int >= 0`): used by `RuntimeConfig.ckpt_time_interval_minutes`.
+- **`UnitIntervalStrictFloat`** (`0.0 <= float <= 1.0`): used by `RuntimeConfig.best_smoothing_alpha`,
+  `RuntimeConfig.ema_decay`.
+- **`PosUnitIntervalStrictFloat`** (`0.0 < float <= 1.0`): used by `SampleConfig.top_p`.
+- **`NonNaNNonNegativeStrictFloat`** (`float >= 0` and not NaN): used by `OptimConfig.grad_clip`,
+  `OptimConfig.weight_decay`.
+- **`EpochCount`** (`AtLeastOneInt` alias): used by `RuntimeConfig.iters_per_epoch`, `RuntimeConfig.max_epochs`.
 
-Examples:
-
-- `RuntimeConfig.eval_interval: AtLeastOneInt`
-- `DataConfig.batch_size: AtLeastOneInt`
-- `ModelConfig.n_layer: PositiveStrictInt`
+Example annotations include `RuntimeConfig.eval_interval: AtLeastOneInt`, `DataConfig.batch_size: AtLeastOneInt`, and
+`ModelConfig.n_layer: PositiveStrictInt`.
 
 ### Path Handling
 
 - Path fields (e.g., `dataset_dir`, `raw_dir`, `out_dir`) are `pathlib.Path` in models.
-- `SharedConfig` is the single authority for resolving project-scoped paths. A `@model_validator(before=True)` resolves `project_home`, `dataset_dir`, `train_out_dir`, and `sample_out_dir` relative to `config_path` when provided as strings or relative Paths.
-- Section models (`PreparerConfig`, `TrainerConfig`, `SamplerConfig`) no longer carry ad-hoc path resolution; they accept already-normalized values. Minimal relative resolution remains for section-local fields when explicitly needed and context is available.
+- `SharedConfig` is the single authority for resolving project-scoped paths. A `@model_validator(before=True)` resolves
+  `project_home`, `dataset_dir`, `train_out_dir`, and `sample_out_dir` relative to `config_path` when provided as
+  strings or relative Paths.
+- Section models (`PreparerConfig`, `TrainerConfig`, `SamplerConfig`) no longer carry ad-hoc path resolution; they
+  accept already-normalized values. Minimal relative resolution remains for section-local fields when explicitly needed
+  and context is available.
 
 ### Loader & CLI Adapters
 
-- Use `ml_playground/configuration/loading.load_full_experiment_config()` for end-to-end resolution (defaults + experiment TOML + `.ldres` overrides).
-- Section helpers `load_train_config`, `load_sample_config`, and `load_prepare_config` live alongside the full loader and apply consistent provenance metadata.
-- CLI code should call `ml_playground/configuration/cli.load_experiment()` and related helpers (`cfg_path_for`, `ensure_*_prerequisites`). Avoid re-implementing filesystem logic inside command handlers.
+- Use `ml_playground/configuration/loading.load_full_experiment_config()` for end-to-end resolution (defaults +
+  experiment TOML + `.ldres` overrides).
+- Section helpers `load_train_config`, `load_sample_config`, and `load_prepare_config` live alongside the full loader
+  and apply consistent provenance metadata.
+- CLI code should call `ml_playground/configuration/cli.load_experiment()` and related helpers (`cfg_path_for`,
+  `ensure_*_prerequisites`). Avoid re-implementing filesystem logic inside command handlers.
 
 ### Logger Behavior
 
 - `ExperimentConfig` always carries a logger via a default factory; the loader/CLI may override it.
-- Section configs (`PreparerConfig`, `TrainerConfig`, `SamplerConfig`) do not define their own logger fields; they inherit common behavior from `_FrozenStrictModel` but remain free of logger extras in the schema.
+- Section configs (`PreparerConfig`, `TrainerConfig`, `SamplerConfig`) do not define their own logger fields; they
+  inherit common behavior from `_FrozenStrictModel` but remain free of logger extras in the schema.
 
 ### Strictness and Unknown Keys
 
@@ -188,48 +205,54 @@ Config validators enforce a few important invariants:
 - If `train.schedule.decay_lr == true` then `train.schedule.min_lr <= train.optim.learning_rate`.
 - If `train.schedule.decay_lr == false` then `train.schedule.warmup_iters == 0`.
 - For tokenization: when `train.data.tokenizer == "tiktoken"`, enforce `train.data.ngram_size == 1`.
-- `RuntimeConfig` cadence and timing fields are range-checked (e.g., `eval_interval >= 1`, `ckpt_time_interval_minutes >= 0`, etc.).
+- `RuntimeConfig` cadence and timing fields are range-checked (e.g., `eval_interval >= 1`, `ckpt_time_interval_minutes
+  >= 0`, etc.).
 
 These validations fail fast with descriptive errors to catch misconfigurations early.
 
 ## Common Pitfalls
 
-- __Relative paths in TOML are not auto-resolved by models__
-  - Models accept `Path` only; loaders resolve TOML strings relative to the config file directory. If constructing models directly in code, pass `Path` objects.
+- **Relative paths in TOML are not auto-resolved by models**
+  - Models accept `Path` only; loaders resolve TOML strings relative to the config file directory. If constructing
+    models directly in code, pass `Path` objects.
 
-- __Missing `[sample.runtime]` section__
-  - `SamplerConfig.runtime` is required; no `runtime_ref` indirections are supported. Define `[sample.runtime]` explicitly in TOML.
+- **Missing `[sample.runtime]` section**
+  - `SamplerConfig.runtime` is required; no `runtime_ref` indirections are supported. Define `[sample.runtime]`
+    explicitly in TOML.
 
-- __Using `tiktoken` with `ngram_size > 1`__
+- **Using `tiktoken` with `ngram_size > 1`**
   - For `DataConfig`, when `tokenizer == "tiktoken"`, set `ngram_size = 1`.
 
-- __Scheduler warmup with `decay_lr = false`__
+- **Scheduler warmup with `decay_lr = false`**
   - If LR decay is disabled, set `warmup_iters = 0`.
 
-- __`min_lr` higher than `learning_rate` when decay is enabled__
+- **`min_lr` higher than `learning_rate` when decay is enabled**
   - Ensure `schedule.min_lr <= optim.learning_rate` when `schedule.decay_lr = true`.
 
-- __`max_iters = 0` for eval-only/smoke flows__
+- **`max_iters = 0` for eval-only/smoke flows**
   - Allowed. `RuntimeConfig.max_iters` can be 0; ensure `eval_interval`, `eval_iters`, and `log_interval` are >= 1.
 
-- __Checkpoint rotation knobs inert by default__
-  - `ckpt_top_k = 0` disables top-k pruning. Set `ckpt_top_k > 0` and ensure metric settings are correct (`ckpt_metric`, `ckpt_greater_is_better`).
+- **Checkpoint rotation knobs inert by default**
+  - `ckpt_top_k = 0` disables top-k pruning. Set `ckpt_top_k > 0` and ensure metric settings are correct (`ckpt_metric`,
+    `ckpt_greater_is_better`).
 
-- __Unknown keys in TOML__
+- **Unknown keys in TOML**
   - All models use `extra="forbid"`. Remove unknown keys or add them under `extras` where appropriate.
 
-- __Logger availability__
-  - `ExperimentConfig` always has a logger (default factory or loader/CLI override). Section configs do not accept a logger field; avoid injecting extras into sections.
+- **Logger availability**
+  - `ExperimentConfig` always has a logger (default factory or loader/CLI override). Section configs do not accept a
+    logger field; avoid injecting extras into sections.
 
 ## Architectural Overview
 
 The framework is designed to be modular and extensible. The core components are:
 
-- __CLI__ - Entry point for all operations
-- __Configuration__ - Manages experiment configuration
-- __Data Preparation__ - Handles dataset preparation and tokenization
-- __Training Package__ - `ml_playground.training` orchestrates the training loop via `loop/`, `hooks/`, and `checkpointing/` modules
-- __Sampler__ - Handles sampling from a trained model
+- **CLI** - Entry point for all operations
+- **Configuration** - Manages experiment configuration
+- **Data Preparation** - Handles dataset preparation and tokenization
+- **Training Package** - `ml_playground.training` orchestrates the training loop via `loop/`, `hooks/`, and
+  `checkpointing/` modules
+- **Sampler** - Handles sampling from a trained model
 
 ## Experiment Utilities
 
@@ -312,60 +335,72 @@ model = GPT(gpt_cfg, logger=exp.logger)
 
 ## Benefits
 
-1. __Reduced Code Duplication__ - Common functionality is now centralized
-2. __Consistent Error Handling__ - Standardized exception classes and error messages
-3. __Better Progress Reporting__ - Unified progress reporting across all experiments
-4. __Enhanced Validation__ - Comprehensive validation utilities for configuration and data
-5. __Improved Maintainability__ - Easier to maintain and update since functionality is centralized
+1. **Reduced Code Duplication** - Common functionality is now centralized
+2. **Consistent Error Handling** - Standardized exception classes and error messages
+3. **Better Progress Reporting** - Unified progress reporting across all experiments
+4. **Enhanced Validation** - Comprehensive validation utilities for configuration and data
+5. **Improved Maintainability** - Easier to maintain and update since functionality is centralized
 
 ## Strict Refactoring Guidance (Binding)
 
-The following guidance operationalizes the Developer Guidelines and Import Standards for framework code and tests. Apply these rules immediately and update tests in lockstep.
+The following guidance operationalizes the Developer Guidelines and Import Standards for framework code and tests. Apply
+these rules immediately and update tests in lockstep.
 
-- __Single Source of Truth for Configuration__
+- **Single Source of Truth for Configuration**
   - Use `ml_playground/config.py` as the only configuration authority.
-  - Prefer `load_experiment_toml()` and strongly typed models: `ExperimentConfig`, `TrainerConfig`, `SamplerConfig`, `RuntimeConfig`.
+  - Prefer `load_experiment_toml()` and strongly typed models: `ExperimentConfig`, `TrainerConfig`, `SamplerConfig`,
+    `RuntimeConfig`.
   - Paths must be `pathlib.Path`. Resolve relative paths relative to the TOML file location, not CWD.
 
-- __Public APIs only (no internal/legacy helpers)__
-  - Tests and modules must import and use public APIs from concrete submodules, never private helpers in `ml_playground/cli.py` or ad-hoc wrappers.
-  - If a test references `cli._internal_*` or `_get_experiment_loader`, delete/replace the test with public-API equivalents.
+- **Public APIs only (no internal/legacy helpers)**
+  - Tests and modules must import and use public APIs from concrete submodules, never private helpers in
+    `ml_playground/cli.py` or ad-hoc wrappers.
+  - If a test references `cli._internal_*` or `_get_experiment_loader`, delete/replace the test with public-API
+    equivalents.
 
-- __Tokenizer Protocol as the only tokenization entrypoint__
+- **Tokenizer Protocol as the only tokenization entrypoint**
   - Use `ml_playground/tokenizer.py` factory `create_tokenizer()` and the `Tokenizer` protocol.
-  - `DataConfig` controls tokenizer selection (`char`, `word`, `tiktoken`) and parameters (e.g., `ngram_size`). Do not re-implement tokenizers in experiments.
+  - `DataConfig` controls tokenizer selection (`char`, `word`, `tiktoken`) and parameters (e.g., `ngram_size`). Do not
+    re-implement tokenizers in experiments.
 
-- __Centralized Error Handling__
+- **Centralized Error Handling**
   - Raise and handle exceptions from `ml_playground/error_handling.py`.
   - Use `safe_file_operation()` and `ProgressReporter` for predictable I/O and progress.
 
-- __Import Hygiene (zero workarounds)__
-  - Absolute, submodule-level imports only. No umbrella re-exports or star imports. No local imports except documented cycle breaks.
+- **Import Hygiene (zero workarounds)**
+  - Absolute, submodule-level imports only. No umbrella re-exports or star imports. No local imports except documented
+    cycle breaks.
   - Follow `.dev-guidelines/Readme.md` (Import Standards) strictly.
 
-- __Tests updated first, then code in small steps__
+- **Tests updated first, then code in small steps**
   - For each refactor, update or remove obsolete tests in the same commit. Run all quality gates before committing.
 
 ## Deprecations and Removals
 
 The following items are legacy/back-compat and must be removed or migrated:
 
-- Obsolete CLI internal helpers (e.g., `ml_playground.cli._get_experiment_loader`, `cli._resolve_and_load_configs`, `cli._apply_train_overrides`, `cli.load_app_config`). Replace with public functions in `ml_playground/config.py` and explicit CLI flows.
-- Ad-hoc config loaders and duplicate path-resolution logic (e.g., alternate `config_loader` modules). Consolidate on `ml_playground/config.py` models and validators.
-- Legacy test assumptions about relative paths and implicit defaults. Tests must create minimal TOMLs and assert behavior via typed models.
+- Obsolete CLI internal helpers (e.g., `ml_playground.cli._get_experiment_loader`, `cli._resolve_and_load_configs`,
+  `cli._apply_train_overrides`, `cli.load_app_config`). Replace with public functions in `ml_playground/config.py` and
+  explicit CLI flows.
+- Ad-hoc config loaders and duplicate path-resolution logic (e.g., alternate `config_loader` modules). Consolidate on
+  `ml_playground/config.py` models and validators.
+- Legacy test assumptions about relative paths and implicit defaults. Tests must create minimal TOMLs and assert
+  behavior via typed models.
 - Backward-compat CLI flags mutating config. Configuration comes from TOML plus well-defined env JSON overrides only.
 
 ## Strict Mode (No Backward Compatibility)
 
-The framework enforces strict behavior across configuration, checkpoints, and tokenizer metadata. Legacy formats and implicit fallbacks are not supported.
+The framework enforces strict behavior across configuration, checkpoints, and tokenizer metadata. Legacy formats and
+implicit fallbacks are not supported.
 
-- __Configuration (TOML-only, strict schema)__
+- **Configuration (TOML-only, strict schema)**
   - Models in `ml_playground/config.py` are the single source of truth.
   - Unknown/extra keys are forbidden (Pydantic `extra="forbid"`).
   - No runtime references/indirections are supported; `SamplerConfig.runtime` must be provided explicitly in TOML.
-  - Path resolution and coercion to `Path` happen in loaders relative to the TOML file; models themselves only accept `Path`.
+  - Path resolution and coercion to `Path` happen in loaders relative to the TOML file; models themselves only accept
+    `Path`.
 
-- __Sampler Checkpoints (rotated files only)__
+- **Sampler Checkpoints (rotated files only)**
   - Sampler loads checkpoints exclusively via `CheckpointManager` rotated files.
   - Supported patterns:
     - Last: `ckpt_last_XXXXXXXX.pt`
@@ -373,18 +408,22 @@ The framework enforces strict behavior across configuration, checkpoints, and to
   - Stable, non-rotated filenames are not used.
   - If no rotated checkpoints exist, a `CheckpointError` is raised.
 
-- __Tokenizer Metadata (required fields)__
+- **Tokenizer Metadata (required fields)**
   - `meta.pkl` must include `tokenizer_type` in {`char`, `word`, `tiktoken`}.
-  - No inference from legacy fields (e.g., `kind`, `stoi`, `itos`, `vocab`). Missing `tokenizer_type` raises `DataError`.
-  - For `char`/`word`, vocab fields (`stoi`/`vocab`) are optional but recommended; for `tiktoken`, `encoding_name` defaults to `cl100k_base` when omitted.
+  - No inference from legacy fields (e.g., `kind`, `stoi`, `itos`, `vocab`). Missing `tokenizer_type` raises
+    `DataError`.
+  - For `char`/`word`, vocab fields (`stoi`/`vocab`) are optional but recommended; for `tiktoken`, `encoding_name`
+    defaults to `cl100k_base` when omitted.
 
-These rules ensure deterministic behavior, type safety, and maintainability. Tests and examples have been updated to comply with strict mode.
+These rules ensure deterministic behavior, type safety, and maintainability. Tests and examples have been updated to
+comply with strict mode.
 
 ## Migration Plan (Step-by-Step)
 
 1) Inventory and delete obsolete tests
    - Remove tests referencing private CLI internals or legacy loaders.
-   - Keep only tests that exercise public APIs (`config.py`, `trainer.py`, `sampler.py`, `prepare.py`, `tokenizer.py`, `checkpoint.py`).
+   - Keep only tests that exercise public APIs (`config.py`, `trainer.py`, `sampler.py`, `prepare.py`, `tokenizer.py`,
+     `checkpoint.py`).
 
 2) Consolidate configuration
    - Replace any usage of alternate loaders with:
@@ -393,7 +432,8 @@ These rules ensure deterministic behavior, type safety, and maintainability. Tes
    - Ensure validation uses strict models; no reference-resolution mechanics are supported.
 
 3) Normalize path handling
-   - Resolve relative paths against the TOML file directory via `SharedConfig`'s pre-validator. Downstream modules must treat these paths as canonical and avoid re-resolving.
+   - Resolve relative paths against the TOML file directory via `SharedConfig`'s pre-validator. Downstream modules must
+     treat these paths as canonical and avoid re-resolving.
 
 4) Tokenization
    - Use `create_tokenizer()` exclusively. Migrate any custom tokenization code into the unified protocol or remove it.
@@ -418,7 +458,8 @@ These rules ensure deterministic behavior, type safety, and maintainability. Tes
 - Replace imports of private CLI helpers with public APIs.
 - Construct minimal TOML files in tests; avoid implicit global defaults unless explicitly passed.
 - Validate types and error messages from Pydantic models directly (no monkeypatching internals).
-- Use `tmp_path` for any filesystem needs; assert on files created by `prepare.write_bin_and_meta()` and checkpoint routines.
+- Use `tmp_path` for any filesystem needs; assert on files created by `prepare.write_bin_and_meta()` and checkpoint
+  routines.
 - Prefer parametrized tests for schedules, learning-rate helpers, and tokenizers.
 
 ## Example: Loading an Experiment

--- a/docs/testing/coverage_baseline.md
+++ b/docs/testing/coverage_baseline.md
@@ -1,12 +1,16 @@
 # Coverage Baseline
 
-_Last updated: 2025-10-01_
+Last updated: 2025-10-02
 
 This document captures the current automated test coverage for the `ml_playground` package and describes how to regenerate the reports. Use it to prioritize work that pushes statement and branch coverage towards 100%.
 
 ---
 
-## Generating the baseline
+## Quick workflow recap
+
+1. Run `make coverage-report` from the project root (UV-managed environment active).
+2. Inspect the terminal summary and open `.cache/coverage/htmlcov/index.html` for interactive drill-down.
+3. Extract module-level metrics from `.cache/coverage/coverage.json` when updating this baseline.
 
 - **Prerequisites**
   - Run inside the project root with the UV-managed virtual environment available.
@@ -33,7 +37,7 @@ The table below lists modules below 90% statement coverage, extracted from `.cac
 | Module | Statements | Missing | Coverage |
 | --- | ---: | ---: | ---: |
 | `ml_playground/training/ema.py` | 16 | 8 | 40.00% |
-| `ml_playground/training/checkpointing/service.py` | 63 | 27 | 54.22% |
+| `ml_playground/training/checkpointing/service.py` | 63 | 20 | 66.27% |
 | `ml_playground/data_pipeline/preparer.py` | 83 | 49 | 33.66% |
 | `ml_playground/models/core/inference.py` | 43 | 18 | 56.14% |
 | `ml_playground/training/loop/runner.py` | 136 | 25 | 78.92% |

--- a/docs/testing/coverage_baseline.md
+++ b/docs/testing/coverage_baseline.md
@@ -1,8 +1,9 @@
 # Coverage Baseline
 
-Last updated: 2025-10-02
+Last updated: 2025-10-02 (after DI trainer refactor)
 
-This document captures the current automated test coverage for the `ml_playground` package and describes how to regenerate the reports. Use it to prioritize work that pushes statement and branch coverage towards 100%.
+This document captures the current automated test coverage for the `ml_playground` package and describes how to
+regenerate the reports. Use it to prioritize work that pushes statement and branch coverage towards 100%.
 
 ---
 
@@ -26,31 +27,35 @@ This document captures the current automated test coverage for the `ml_playgroun
   - JSON report at `.cache/coverage/coverage.json` (machine-readable; used for scripting).
 - **Notes**
   - The Make target runs `pytest` serially (`-n 0`) with the `not perf` marker filter.
-  - Coverage reports temporarily override `fail_under` to zero so artifacts always generate, even while total coverage is below the ultimate goal. CI guardrails will be restored once coverage approaches 100%.
+  - Coverage reports temporarily override `fail_under` to zero so artifacts always generate, even while total coverage
+    is below the ultimate goal. CI guardrails will be restored once coverage approaches 100%.
 
 ---
 
 ## Lowest-covered modules (statement %)
 
-The table below lists modules below 90% statement coverage, extracted from `.cache/coverage/coverage.json` after running `make coverage-report` on 2025-10-01.
+The modules below fell under 90% statement coverage when `make coverage-report` was run on 2025-10-02 (data from
+`.cache/coverage/coverage.json`):
 
-| Module | Statements | Missing | Coverage |
-| --- | ---: | ---: | ---: |
-| `ml_playground/training/ema.py` | 16 | 8 | 40.00% |
-| `ml_playground/training/checkpointing/service.py` | 63 | 20 | 66.27% |
-| `ml_playground/data_pipeline/preparer.py` | 83 | 49 | 33.66% |
-| `ml_playground/models/core/inference.py` | 43 | 18 | 56.14% |
-| `ml_playground/training/loop/runner.py` | 136 | 25 | 78.92% |
-| `ml_playground/core/logging_protocol.py` | 9 | 0 (branches) | 76.47% |
-| `ml_playground/core/tokenizer_protocol.py` | 14 | 2 | 75.00% |
-| `ml_playground/sampling/runner.py` | 98 | 17 | 78.69% |
-| `ml_playground/training/hooks/logging.py` | 11 | 2 | 76.92% |
-| `ml_playground/experiments/bundestag_qwen15b_lora_mps/preparer.py` | 44 | 35 | 15.52% |
-| `ml_playground/experiments/bundestag_qwen15b_lora_mps/sampler.py` | 10 | 10 | 0.00% |
-| `ml_playground/experiments/bundestag_qwen15b_lora_mps/trainer.py` | 10 | 10 | 0.00% |
-| `ml_playground/experiments/bundestag_tiktoken/preparer.py` | 40 | 29 | 27.50% |
-| `ml_playground/experiments/speakger/preparer.py` | 13 | 6 | 53.85% |
-| `ml_playground/experiments/speakger/sampler.py` | 99 | 21 | 78.99% |
+- **`ml_playground/training/ema.py`** — statements: 16, missing: 8, coverage: 40.00%.
+- **`ml_playground/training/checkpointing/service.py`** — statements: 63, missing: 20, coverage: 66.27%.
+- **`ml_playground/data_pipeline/preparer.py`** — statements: 83, missing: 49, coverage: 33.66%.
+- **`ml_playground/models/core/inference.py`** — statements: 43, missing: 18, coverage: 56.14%.
+- **`ml_playground/training/loop/runner.py`** — statements: 176, missing: 32, coverage: 87.02%.
+- **`ml_playground/core/logging_protocol.py`** — statements: 9, branch misses only, coverage: 76.47%.
+- **`ml_playground/core/tokenizer_protocol.py`** — statements: 14, missing: 2, coverage: 75.00%.
+- **`ml_playground/sampling/runner.py`** — statements: 98, missing: 17, coverage: 78.69%.
+- **`ml_playground/training/hooks/logging.py`** — statements: 11, missing: 2, coverage: 76.92%.
+- **Bundestag Qwen 1.5B LoRA preparer** (`experiments/bundestag_qwen15b_lora_mps/preparer.py`) — statements: 44,
+  missing: 35, coverage: 15.52%.
+- **Bundestag Qwen 1.5B LoRA sampler** (`experiments/bundestag_qwen15b_lora_mps/sampler.py`) — statements: 10,
+  missing: 10, coverage: 0.00%.
+- **Bundestag Qwen 1.5B LoRA trainer** (`experiments/bundestag_qwen15b_lora_mps/trainer.py`) — statements: 10,
+  missing: 10, coverage: 0.00%.
+- **Bundestag Tiktoken preparer** (`experiments/bundestag_tiktoken/preparer.py`) — statements: 40, missing: 29,
+  coverage: 27.50%.
+- **SpeakGER preparer** (`experiments/speakger/preparer.py`) — statements: 13, missing: 6, coverage: 53.85%.
+- **SpeakGER sampler** (`experiments/speakger/sampler.py`) — statements: 99, missing: 21, coverage: 78.99%.
 
 _Additional modules may fall below 90% once new code lands; regenerate the report before starting each coverage sprint._
 
@@ -59,15 +64,21 @@ _Additional modules may fall below 90% once new code lands; regenerate the repor
 ## Using the baseline in PRs
 
 - **Before coding**: Review the table (and HTML report) to choose a module with the largest gap.
-- **During development**: Run targeted tests frequently, then `make coverage-report` before opening the PR to ensure deltas are captured.
+- **During development**: Run targeted tests frequently, then `make coverage-report` before opening the PR to ensure
+  deltas are captured.
 - **In PR description**: Mention the new coverage percentage for the touched module(s) and link to relevant test files.
 - **Post-merge**: Re-run `make coverage-report` on `master` to keep the baseline current.
-- **Fixture discipline**: Follow the guidance in `.dev-guidelines/TESTING.md#fixtures-strict-usage` and `tests/unit/README.md#fixtures--collaborators`; prefer inline stubs/DI over monkeypatching or new fixtures unless they belong in an existing `conftest.py`.
+- **Fixture discipline**: Follow the guidance in
+  `.dev-guidelines/TESTING.md#fixtures-strict-usage` and
+  `tests/unit/README.md#fixtures--collaborators`; prefer inline stubs/DI over monkeypatching or new fixtures unless
+  they belong in an existing `conftest.py`.
 
 ---
 
 ## Next steps
 
-- **Task 2** (`/.ldres/tv-tasks.md`): Raise unit coverage for `ml_playground/training/checkpointing/service.py`, `ml_playground/training/loop/runner.py`, and `ml_playground/core/tokenizer.py` to ≥99% statements / ≥95% branches.
+- **Task 2** (`/.ldres/tv-tasks.md`): Raise unit coverage for
+  `ml_playground/training/checkpointing/service.py`, `ml_playground/training/loop/runner.py`, and
+  `ml_playground/core/tokenizer.py` to ≥99% statements / ≥95% branches.
 - **Task 3**: Strengthen CLI and E2E coverage for `ml_playground/cli.py` and related entry points.
 - **Task 4**: Once coverage gaps shrink, re-enable strict `fail_under` thresholds in CI.

--- a/ml_playground/configuration/README.md
+++ b/ml_playground/configuration/README.md
@@ -1,26 +1,30 @@
 # Configuration Package
 
 ## Purpose
-Configuration models and loading utilities for ml_playground. Provides strict typing, validation, and TOML-based configuration management with override support.
+
+Configuration management utilities for `ml_playground`. Provides Pydantic models and loading helpers for experiment
+configs.
 
 ## Structure
-- `models.py` - Pydantic configuration models and validation
-- `loading.py` - Configuration loading, merging, and resolution
-- `cli.py` - CLI-specific configuration adapters
+
+- `models.py` - Pydantic configuration models
+- `loading.py` - TOML loading and deep merge helpers
 
 ## Key APIs
-- `ExperimentConfig` - Complete experiment configuration
-- `TrainerConfig` / `SamplerConfig` / `PreparerConfig` - Section-specific configs
-- `load_full_experiment_config()` - Load and merge experiment configuration
-- `load_train_config()` / `load_sample_config()` - Partial config loading
+
+- `ExperimentConfig` - Complete configuration tree
+- `TrainerConfig` - Training-specific configuration
+- `load_full_experiment_config()` - Load and validate experiment configuration
 
 ## Usage Example
+
 ```python
-from ml_playground.configuration import load_full_experiment_config
+from ml_playground.configuration.loading import load_full_experiment_config
 
 config = load_full_experiment_config(config_path, project_home, experiment_name)
 ```
 
 ## Related Documentation
-- [Framework Utilities](../docs/framework_utilities.md) - Configuration structure
+
+- [Framework Utilities](../docs/framework_utilities.md) - Configuration guidelines
 - [Development Guidelines](../.dev-guidelines/DEVELOPMENT.md) - Configuration policies

--- a/ml_playground/data_pipeline/README.md
+++ b/ml_playground/data_pipeline/README.md
@@ -1,30 +1,32 @@
 # Data Pipeline Package
 
 ## Purpose
-Data pipeline utilities for preparing, transforming, and batching training data in ml_playground experiments. Handles tokenization, data loading, and batch sampling with strict typing and validation.
+
+Data pipeline utilities for preparing, transforming, and batching training data in `ml_playground` experiments. Handles
+tokenization, data loading, and batch sampling with strict typing and validation.
 
 ## Structure
-- `preparer.py` - Main data preparation orchestration
-- `transforms/` - Data transformation utilities (tokenization, I/O operations)
-- `sampling/` - Batch sampling and data loading utilities
-- `sources/` - Data source implementations (memory-mapped files, etc.)
+
+- `preparer.py` - Main data preparation workflow
+- `tokenizers.py` - Tokenizer interface and implementations
 
 ## Key APIs
-- `create_pipeline()` - Data pipeline factory function
-- `PreparationOutcome` - Structured preparation result
-- `prepare_with_tokenizer()` - Tokenization and splitting pipeline
-- `SimpleBatches` - Training batch iterator
-- `MemmapReader` - Memory-efficient data reading
+
+- `create_pipeline()` - Data pipeline factory
+- `prepare_dataset()` - Run preparation workflow
+- `write_metadata()` - Persist standardized metadata
 
 ## Usage Example
+
 ```python
-from ml_playground.data_pipeline import create_pipeline
-from ml_playground.configuration.models import PreparerConfig
+from ml_playground.data_pipeline.preparer import prepare_dataset
+from ml_playground.core.tokenizer import create_tokenizer
 
 pipeline = create_pipeline(config, shared_config)
 outcome = pipeline.run()
 ```
 
 ## Related Documentation
-- [Framework Utilities](../docs/framework_utilities.md) - Data configuration
+
+- [Framework Utilities](../docs/framework_utilities.md) - Data preparation guidelines
 - [Development Guidelines](../.dev-guidelines/DEVELOPMENT.md) - Data handling standards

--- a/ml_playground/models/README.md
+++ b/ml_playground/models/README.md
@@ -1,18 +1,23 @@
 # Models Package
 
 ## Purpose
-Neural network architecture and model implementations for ml_playground. Provides modular GPT-based models with proper initialization, inference, and optimization support.
+
+Neural network architecture and model implementations for `ml_playground`. Provides modular GPT-based models with proper
+initialization, inference, and optimization support.
 
 ## Structure
+
 - `core/` - Core model implementations (GPT, configuration, inference)
 - `layers/` - Reusable neural network layers (attention, MLP, normalization)
 
 ## Key APIs
+
 - `GPT` - Main transformer model class
 - `GPTConfig` - Model architecture configuration
 - `build_gpt_config()` - Configuration factory from experiment config
 
 ## Usage Example
+
 ```python
 from ml_playground.models.core.model import GPT
 from ml_playground.models.core.config import GPTConfig
@@ -22,4 +27,5 @@ model = GPT(config)
 ```
 
 ## Related Documentation
+
 - [Framework Utilities](../docs/framework_utilities.md) - Model configuration options

--- a/ml_playground/sampling/README.md
+++ b/ml_playground/sampling/README.md
@@ -1,17 +1,22 @@
 # Sampling Package
 
 ## Purpose
-Model inference and text generation utilities for ml_playground. Provides checkpoint loading, model setup, and sampling orchestration with proper error handling.
+
+Model inference and text generation utilities for `ml_playground`. Provides checkpoint loading, model setup, and
+sampling orchestration with proper error handling.
 
 ## Structure
+
 - `runner.py` - Main sampling implementation and orchestration
 
 ## Key APIs
+
 - `Sampler` - Sampling orchestrator class
 - `sample()` - Functional sampling interface
 - `run_server_bundestag_char()` - LIT integration demo
 
 ## Usage Example
+
 ```python
 from ml_playground.sampling.runner import Sampler
 from ml_playground.configuration.models import SamplerConfig
@@ -21,5 +26,6 @@ sampler.run()
 ```
 
 ## Related Documentation
+
 - [Framework Utilities](../docs/framework_utilities.md) - Sampling configuration
 - [LIT Integration](../docs/LIT.md) - Web-based model analysis

--- a/ml_playground/training/README.md
+++ b/ml_playground/training/README.md
@@ -1,20 +1,25 @@
 # Training Package
 
 ## Purpose
-Training orchestration package providing complete training loop management, checkpointing, evaluation hooks, and LR scheduling for machine learning models in ml_playground.
+
+Training orchestration package providing complete training loop management, checkpointing, evaluation hooks, and LR
+scheduling for machine learning models in `ml_playground`.
 
 ## Structure
+
 - `loop/` - Core training loop orchestration and runner
 - `checkpointing/` - Checkpoint save/load and management services
 - `hooks/` - Training lifecycle hooks (evaluation, logging, model setup, data loading)
 
 ## Key APIs
+
 - `Trainer` - Main training orchestrator class
 - `train()` - Functional training interface
 - `create_manager()` - Checkpoint manager factory
 - `save_checkpoint()` / `load_checkpoint()` - Checkpoint operations
 
 ## Usage Example
+
 ```python
 from ml_playground.training.loop.runner import Trainer
 from ml_playground.configuration.models import TrainerConfig
@@ -24,5 +29,6 @@ final_iter, best_loss = trainer.run()
 ```
 
 ## Related Documentation
+
 - [Framework Utilities](../docs/framework_utilities.md) - Training configuration
 - [Development Guidelines](../.dev-guidelines/DEVELOPMENT.md) - Quality standards

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,6 +1,7 @@
 # End-to-End (E2E) Tests
 
-E2E tests exercise the application via public entry points (usually the CLI) in a realistic, but tiny, environment. They validate wiring across modules, configuration loading/merging, logging, and basic I/O.
+E2E tests exercise the application via public entry points (usually the CLI) in a realistic, but tiny, environment.
+They validate wiring across modules, configuration loading/merging, logging, and basic I/O.
 
 ## Principles
 

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,6 +1,7 @@
 # Integration Tests
 
-Integration tests verify that multiple components work together correctly via Python APIs (not necessarily the CLI). They use real code paths and small in-memory or tiny on-disk data.
+Integration tests verify that multiple components work together correctly via Python APIs (not necessarily the CLI).
+They use real code paths and small in-memory or tiny on-disk data.
 
 ## Principles
 

--- a/tests/unit/README.md
+++ b/tests/unit/README.md
@@ -1,6 +1,7 @@
 # Unit Tests
 
-Unit tests validate individual functions, classes, and small modules in isolation. They should be trivial to read and fast to run.
+Unit tests validate individual functions, classes, and small modules in isolation. They should be trivial to read and fast
+to run.
 
 ## Principles
 
@@ -10,20 +11,34 @@ Unit tests validate individual functions, classes, and small modules in isolatio
 
 ## Fixtures & collaborators
 
-- Keep unit tests self-contained. Prefer inline stub classes or dependency injection instead of monkeypatching or mocking.
-- When shared setup is unavoidable, reuse fixtures defined in `tests/conftest.py` or a package-local `conftest.py`; keep them pure and deterministic.
+- Keep unit tests self-contained. Prefer inline stub classes or dependency injection instead of monkeypatching or
+  mocking.
+- When shared setup is unavoidable, reuse fixtures defined in `tests/conftest.py` or a package-local `conftest.py`;
+  keep them pure and deterministic.
 - Follow the canonical guidance in `.dev-guidelines/TESTING.md#fixtures-strict-usage` for scope and purity rules.
+
+## Naming
+
+- **File names**: `test_<module>.py` within the corresponding directory (e.g.,
+  `tests/unit/training/checkpointing/test_service.py`).
+- **Test functions**: Prefer `test_<unit_of_behavior>_<expected_outcome>` (snake_case, verbs included when meaningful).
+- **Helpers/stubs**: Prefix with `_Stub` or `_make_` to signal test-only collaborators and avoid collisions with
+  production symbols.
 
 ## Testing Approaches
 
 ### Traditional Unit Tests
+
 Standard unit tests that validate specific behaviors with hand-crafted examples.
 
 ### Property-Based Tests
+
 Property-based tests using Hypothesis to validate invariants across a wide range of generated inputs:
 
-- **Configuration System**: Tests dictionary merging, TOML serialization, and path computation with generated data structures
-- **Data Loading Logic**: Tests batch sampling, memory mapping, and device placement with various array sizes and configurations
+- **Configuration System**: Tests dictionary merging, TOML serialization, and path computation with generated data
+  structures
+- **Data Loading Logic**: Tests batch sampling, memory mapping, and device placement with various array sizes and
+  configurations
 {{ ... }}
 
 ## Run Locally

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,18 +1,18 @@
 # tools/
 
-Centralized developer tools and helper scripts for ml_playground. All tools are invoked via UV-managed Python (no raw pip, no manual venv activation).
+Centralized developer utilities and helper scripts that support the `ml_playground` project. These are optional, mostly
+used for convenience during development. (No raw pip, no manual venv activation).
 
 ## Purpose
 
 - Provide small, focused utilities used during development and maintenance.
 - Keep operational scripts discoverable and documented in one place.
-- Ensure consistent, reproducible execution via the project venv.
 
 ## Structure
 
 - `port_kill.py` — kill a process bound to a TCP port (Mac/Linux).
 - `cleanup_ignored_tracked.py` — remove accidentally tracked files that should be ignored.
-- `setup_ai_guidelines.py` — bootstrap or update developer guideline docs.
+- `setup_ai_guidelines.py`: Configures symlinks for AI pair-programming workflow per guideline docs.
 - `llama_cpp/` — vendor instructions and helpers for GGUF conversion.
 
 ## Usage


### PR DESCRIPTION
## Summary
- wrap markdown docs to satisfy markdownlint (MD013/MD022/MD032/MD031)
- add .markdownlint-cli2.jsonc and pass it via pre-commit
- keep Trainer code unchanged; markdown-only change set

## Testing
- uv run make quality