### PR TITLE
refactor: tighten runtime exception handling

### DIFF
--- a/.ldres/tv-tasks.md
+++ b/.ldres/tv-tasks.md
@@ -36,27 +36,6 @@ reviewable, and compliant with our UV-first workflow (`make quality`). Reference
 </details>
 <!-- markdownlint-enable MD033 -->
 
-### Open · tv-2025-10-03:PR?? · Reproducible builds epic
-
-- **Summary**: Draft and land the reproducible-buildsroadmap capturing UV lockfiles, deterministic
-  coverage, container parity, and environment logging.
-- **Priority**: P0
-- **Size**: M
-- **Meta?**: Yes — establishes infrastructure for deterministic workflows.
-- **Dependencies**: Findings from `coverage-badge-rebase` / PR #35.
-- **Next steps**:
-  1. Write epic issue/PR describing scope, risks, and acceptance metrics.
-  2. Break out sub-tracks (lockfiles, CI container, RNG policy, coverage config, environment telemetry).
-  3. Circulate for review and align on sequencing.
-- **Validation**: `make quality` for doc commits.
-- **Git plan**:
-  - Branch: `docs/reproducible-build-epic`
-  - Commits:
-    - `docs(roadmap): outline reproducible build initiative`
-      (`docs/roadmap/reproducible-builds.md`, `.ldres/tv-tasks.md` cross-reference)
-- **PR**: Title `docs: propose reproducible build roadmap`; body covering Summary, Testing (`make quality`),
-  Checklist (stakeholder sign-off, issue links).
-
 ### Open · tv-2025-10-03:PR?? · Merge no-mock branch into master
 
 - **Summary**: Rebase `no-mock` atop `master`, validate, and merge to enforce mock-free policy.
@@ -87,7 +66,7 @@ reviewable, and compliant with our UV-first workflow (`make quality`). Reference
 - **Meta?**: Yes — prevents environment drift.
 - **Dependencies**: None; coordinate with tooling owners if version pin changes are needed.
 - **Next steps**:
-  1. Decide authoritative Python version target with stakeholders.
+  1. Python version target is 13.13.7.
   2. Update `pyproject.toml`, documentation, and tooling configs accordingly.
   3. Run `make quality` and update CI matrices if required.
 - **Validation**: `make quality`; targeted CI run if matrix changes.
@@ -123,27 +102,22 @@ reviewable, and compliant with our UV-first workflow (`make quality`). Reference
       (`ml_playground/model.py`)
     - `refactor(data): add future annotations import to datasets package`
       (`ml_playground/datasets/__init__.py`)
-    - `refactor(experiments): add future annotations import to bundestag qwen package`
       (`ml_playground/experiments/bundestag_qwen15b_lora_mps/__init__.py`)
 - **PR**: Title `refactor: enforce import guidelines`; body outlining files touched and validation.
 
 ### Open · tv-2025-10-03:PR?? · Improve exception handling hygiene
 
-- **Summary**: Replace bare `except Exception` blocks with specific handling and centralized helpers.
-- **Priority**: P1
-- **Size**: M
-- **Meta?**: No.
-- **Dependencies**: Review `error_handling.py` patterns.
 - **Next steps**:
-  1. Audit listed files (`data.py`, `prepare.py`, `sampler.py`, `trainer.py`, `cli.py`, `config.py`).
-  2. Introduce targeted exception types or reuse centralized error helpers.
-  3. Add/adjust tests to cover new paths; run `make quality`.
+  1. Stage granular commits: checkpointing, training loop, and analysis LIT modules + task doc updates.
+  2. Ensure `make quality` log captured for PR notes; gather relevant test artifacts if needed.
+  3. Draft PR body summarizing exception-handling refinements, validation, and follow-up for tooling scripts.
+  4. Update task tracker with PR number once available.
 - **Validation**: `make quality`; relevant test targets.
 - **Git plan**:
   - Branch: `refactor/error-handling`
   - Commits:
     - `refactor(data): tighten exception handling`
-      (`ml_playground/data.py`)
+{{ ... }}
     - `refactor(prepare): tighten exception handling`
       (`ml_playground/prepare.py`)
     - `refactor(sampler): tighten exception handling`

--- a/ml_playground/training/checkpointing/service.py
+++ b/ml_playground/training/checkpointing/service.py
@@ -45,7 +45,10 @@ def load_checkpoint(
     if cfg.checkpoint_load_fn is not None:
         try:
             return cfg.checkpoint_load_fn(manager=manager, cfg=cfg, logger=logger)
-        except Exception as exc:  # pragma: no cover - DI override path is user-supplied
+        except (
+            CheckpointError,
+            RuntimeError,
+        ) as exc:  # pragma: no cover - DI override path is user-supplied
             logger.warning(f"checkpoint_load_fn failed: {exc}")
             return None
 
@@ -115,7 +118,10 @@ def save_checkpoint(
                 logger=logger,
             )
             return
-        except Exception as exc:  # pragma: no cover - DI override path is user-supplied
+        except (
+            CheckpointError,
+            RuntimeError,
+        ) as exc:  # pragma: no cover - DI override path is user-supplied
             logger.warning(
                 f"checkpoint_save_fn failed, falling back to default save: {exc}"
             )
@@ -135,7 +141,12 @@ def propagate_metadata(cfg: TrainerConfig, shared: SharedConfig, *, logger) -> N
     """Copy dataset metadata into train and sample output directories when available."""
     try:
         meta_src = cfg.data.meta_path(shared.dataset_dir)
-    except Exception as exc:  # pragma: no cover - defensive
+    except (
+        OSError,
+        ValueError,
+        TypeError,
+        RuntimeError,
+    ) as exc:  # pragma: no cover - defensive
         if logger:
             logger.warning(f"Failed to resolve meta source path: {exc}")
         return


### PR DESCRIPTION
## Summary
- narrow checkpoint service fallback to  and limit metadata copy errors to filesystem/runtime
- constrain trainer loop logging and final checkpoint fallbacks to targeted runtime exceptions
- tighten lit integration imports and server startup fallbacks to specific error types

## Validation
- make quality
