### PR TITLE
docs: document related documentation template

### DIFF
--- a/.dev-guidelines/DOCUMENTATION.md
+++ b/.dev-guidelines/DOCUMENTATION.md
@@ -71,6 +71,25 @@ ml_playground/experiments/shakespeare/
 - When linking to another folder, link to that folder's `Readme.md` (single entry point) instead of deep files. Deep
   documents should be discovered from that folder's `Readme.md`.
 
+## Cross-Document Details Blocks
+
+- Place a `<details>` block titled `Related documentation` near the top of READMEs that reference other guidelines.
+- Each list item inside the block must be a relative Markdown link whose summary sentence is derived from the first
+  paragraph or block of text immediately following the referenced document's top-level heading.
+- Keep the list minimal—link only to documents that provide indispensable context.
+- Update the referenced document summary if its opening paragraph changes.
+
+### Template
+
+```markdown
+<details>
+<summary>Related documentation</summary>
+
+- [Document Title](./DOCUMENTATION.md) – First-paragraph summary from the referenced document.
+
+</details>
+```
+
 ## DRY Documentation
 
 - Avoid repeating extensive “what each file does” prose—lean on the annotated folder tree.

--- a/.dev-guidelines/TESTING.md
+++ b/.dev-guidelines/TESTING.md
@@ -229,17 +229,19 @@ exceptions. NO second chances.
 
 ## Mutation Testing (Optional)
 
-- We use Cosmic Ray for mutation testing; configuration lives in `pyproject.toml` under `[tool.cosmic-ray]`.
-- Run manually when desired:
-
-```bash
-make quality-ext
-```
-
-- This initializes (if needed) and executes Cosmic Ray sessions at `.cache/cosmic-ray/session.sqlite`. The step is
-  non-fatal and not part of CI or pre-commit by default.
-- The `.cache/cosmic-ray/` directory is treated like other build artifacts: never commit it, clean it with `make clean`
-  if needed.
+- **Tooling**: Cosmic Ray configuration lives in `pyproject.toml` under `[cosmic-ray]`.
+- **Primary command**:
+  ```bash
+  make mutation
+  ```
+  This target resets `.cache/cosmic-ray/session.sqlite`, prints the active configuration via `tools/mutation_summary.py`,
+  runs `cosmic-ray init/exec`, and finishes with `tools/mutation_report.py` to display survivor counts.
+- **Default scope**: `module-path = "ml_playground"`, exercising the entire package with
+  `pytest -q -n auto tests/unit` and a 1 s timeout per mutant/test run.
+- **Latest baseline (2025-10-06)**: `make mutation` processed **5 314** mutants (killed: **5 312**, incompetent: **2**)
+  in approximately **1 h 31 m** wall-clock time.
+- **Session hygiene**: The Make target deletes the session DB on every run; do not commit `.cache/cosmic-ray/`.
+- **Follow-up**: Survivor automation and module-specific hardening tasks are tracked in `.ldres/tv-tasks.md`.
 
 ## Running Tests
 

--- a/.ldres/tv-tasks.md
+++ b/.ldres/tv-tasks.md
@@ -112,32 +112,51 @@ reviewable, and compliant with our UV-first workflow (`make quality`). Reference
   1. Track additional optimizations (e.g., memmap fixture changes) and rerun `pytest --durations=20` after each iteration; update this log with new baselines.
 - **Validation**: `make quality`; targeted `pytest --durations=20` reruns on affected suites.
 - **Git plan**:
-  - Branch: `ci/test-speedup`
   - Commits:
     - `ci(pytest): profile test runtimes and document hotspots`
     - `ci(pytest): apply performance optimizations`
 - **PR**: Title `ci: accelerate test execution`; body covering baseline, optimizations, and measured wins.
 
-### In progress · tv-2025-10-05:mutation · Introduce mutation testing
-
-- **Summary**: After coverage gating, introduce mutation-based testing (e.g., `cosmic-ray`) to measure test
-  effectiveness.
-- **Priority**: P1
-- **Size**: M
-- **Meta?**: Yes — improves future test quality.
 - **Dependencies**: Coverage roadmap task; reproducible-build epic for tool integration.
+- **Latest baseline (2025-10-06)**:
+  - `make mutation` (module-path `ml_playground/`, timeout 1 s) processed **5 314** mutants (killed: 5 312,
+    incompetent: 2) in ~**1 h 31 m** wall clock.
 - **Next steps**:
-  1. Audit current mutation tool configs (remove `mutmut` residuals; align with `cosmic-ray`).
-  1. Define initial mutation targets (critical modules) and thresholds for pass/fail.
-  1. Integrate mutation runs into CI (nightly or gated) with summarized reporting.
-- **Validation**: `make quality`; targeted `cosmic-ray` run.
+  1. Ship an automation pipeline that ingests `cosmic-ray` survivors and opens draft PRs with proposed fixes
+     after long-running CI jobs (script + workflow).
+  1. Triage surviving mutants by module and harden tests iteratively:
+     - `ml_playground/training/checkpointing/`
+     - `ml_playground/core/`
+     - `ml_playground/models/`
+     - `ml_playground/data_pipeline/`
+     - `ml_playground/sampling/`
+  1. Track survivor counts per module after each run and update this task with progress metrics.
+- **Validation**: `make mutation`; targeted survivor-specific pytest slices.
 - **Git plan**:
-  - Branch: `test/mutation-suite`
+  - Branch: `test/mutation-hardening`
   - Commits:
-    - `chore(cosmic-ray): configure mutation testing targets` (`pyproject.toml`, `.github/workflows/mutation.yml`)
-    - `docs(testing): document mutation workflow` (`docs/testing/mutation.md`)
-- **PR**: Title `test: introduce mutation testing workflow`; body outlining configuration, validation, and
-  follow-up tasks.
+    - `chore(cosmic-ray): automate survivor extraction` (`tools/`, `.github/workflows/`)
+    - `test(<module>): strengthen tests against survivor diff`
+    - `docs(testing): update mutation workflow guidance`
+- **PR**: Title `test: harden mutation workflow`; body covering automation, survivor stats, and validation.
+
+### Open · tv-2025-10-06:PR?? · Align READMEs with cross-doc details policy
+
+- **Summary**: Apply the new `Related documentation` details-block template across remaining README files so cross-links stay consistent and summarized.
+- **Priority**: P2
+- **Size**: S
+- **Meta?**: Yes — enforces documentation guidelines.
+- **Dependencies**: New policy in `.dev-guidelines/DOCUMENTATION.md`.
+- **Next steps**:
+  1. Audit README files beyond `tests/unit/` and `tests/property/` for related-doc references.
+  1. Insert or update `<details>` blocks with relative links and first-paragraph summaries per the template.
+  1. Note any documents lacking clear intro paragraphs and schedule follow-up edits if needed.
+- **Validation**: `make quality` (mdformat + lint).
+- **Git plan**:
+  - Branch: `docs/related-details-rollout`
+  - Commits:
+    - `docs(guidelines): apply related-document template across READMEs`
+- **PR**: Title `docs: align READMEs with related documentation template`; body summarizing updated files and guideline compliance.
 
 ## Deferred tasks (updated 2025-10-03)
 

--- a/tests/property/README.md
+++ b/tests/property/README.md
@@ -1,5 +1,14 @@
 # Property-Based Tests
 
+<details>
+<summary>Related documentation</summary>
+
+- [Documentation Guidelines](../../.dev-guidelines/DOCUMENTATION.md) – Unified standards for all repository docs, covering top-level, module, test, and tool content.
+- [Testing Standards](../../.dev-guidelines/TESTING.md) – Strict TDD workflow: write a failing test, implement the minimal fix, then refactor safely with green builds.
+- [Unit Tests README](../unit/README.md) – Unit tests validate individual functions, classes, and small modules in isolation.
+
+</details>
+
 Property-based tests validate invariants across large input spaces using Hypothesis.
 They run alongside unit tests but live in this dedicated suite so Hypothesis-specific
 configuration stays isolated.
@@ -35,8 +44,3 @@ tests/property/
 - **Codify**: Translate the minimal input into a deterministic check using `@example(...)` or an explicit unit/property test. Prefer fixtures/helpers over hard-coded globals.
 - **Verify**: Rerun the relevant module (`uv run pytest tests/property/<path>/test_*.py`) to ensure the new guardrails fail without the fix and pass with it.
 - **Document**: Leave a brief comment referencing the original failure or issue to aid future triage.
-
-## Related Documentation
-
-- `.dev-guidelines/TESTING.md` – Hypothesis guidance, coverage gates, fixture rules.
-- `tests/unit/README.md` – complementary unit-test conventions.

--- a/tests/unit/README.md
+++ b/tests/unit/README.md
@@ -1,5 +1,14 @@
 # Unit Tests
 
+<details>
+<summary>Related documentation</summary>
+
+- [Documentation Guidelines](../../.dev-guidelines/DOCUMENTATION.md) – Unified standards for all repository docs, covering top-level, module, test, and tool content.
+- [Testing Standards](../../.dev-guidelines/TESTING.md) – Strict TDD workflow: write a failing test, implement the minimal fix, then refactor safely with green builds.
+- [Property-Based Tests README](../property/README.md) – Property-based tests validate invariants across large input spaces in a dedicated suite.
+
+</details>
+
 Unit tests validate individual functions, classes, and small modules in isolation. They should be trivial to read and fast
 to run.
 
@@ -57,3 +66,8 @@ tests/unit/
 ├── test_public_api_policy.py       - enforcement of public API policy
 └── conftest.py                     - unit pytest fixtures and helpers
 ```
+
+## Documentation
+
+- **\[Guidelines\]** Follow `.dev-guidelines/DOCUMENTATION.md` when editing this README or adding explanatory files.
+- **\[Testing alignment\]** Cross-check `.dev-guidelines/TESTING.md` to keep principles and fixture guidance in sync.


### PR DESCRIPTION
## Summary
- add a reusable Related documentation details template to `.dev-guidelines/DOCUMENTATION.md`
- document the mutation workflow in `.dev-guidelines/TESTING.md`
- update testing READMEs and task list to reference the new guidance

## Testing
- make quality